### PR TITLE
phy: serial: Automatically configure low latency on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/rahix/profirust"
 
 [features]
 phy-linux = ["rs485", "libc", "std"]
-phy-serial = ["serialport", "std"]
+phy-serial = ["serialport", "std", "serialport_low_latency"]
 phy-simulator = ["std"]
 phy-rp2040 = ["rp2040-hal", "fugit", "embedded-hal", "nb", "cortex-m"]
 std = ["managed/std"]
@@ -36,6 +36,9 @@ nb = { version = "1.1.0", optional = true }
 rp2040-hal = { version = "0.9.0", optional = true }
 rs485 = { version = "0.1.0", optional = true }
 serialport = { version = "4.6.0", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+serialport_low_latency = { version = "0.1.1", optional = true }
 
 [workspace]
 members = [


### PR DESCRIPTION
Use the `serialport_low_latency` [^1] crate to automatically configure serial ports for low latency if possible.  Unfortunately, the crate only supports Linux for the time being - on other platforms, low latency has to be configured manually by other means.

[^1]: https://github.com/michaellass/serialport_low_latency